### PR TITLE
0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ metronome = Metronome(0.2, lambda: print('go!'), logger=logger)
 metronome.start()
 sleep(1)
 metronome.stop()
-#> 2024-04-18 19:38:42,910 [INFO] The metronome starts.
+#> 2024-04-18 19:38:42,910 [INFO] The metronome starts...
 #> 2024-04-18 19:38:42,910 [DEBUG] The beginning of the execution of callback "<lambda>".
 #> go!
 #> 2024-04-18 19:38:42,910 [DEBUG] Callback "<lambda>" has been successfully completed.
@@ -144,7 +144,7 @@ metronome = Metronome(0.2, function, logger=logger)
 metronome.start()
 sleep(0.4)
 metronome.stop()
-#> 2024-04-18 19:58:10,847 [INFO] The metronome starts.
+#> 2024-04-18 19:58:10,847 [INFO] The metronome starts...
 #> 2024-04-18 19:58:10,847 [DEBUG] The beginning of the execution of callback "function".
 #> 2024-04-18 19:58:10,847 [ERROR] The "ZeroDivisionError" ("division by zero") exception was suppressed inside the context.
 #> Traceback (most recent call last):

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ print(metronome.stopped)
 #> True
 ```
 
+You can also pass a token when calling the `start()` method:
+
+```python
+metronome.start(token=TimeoutToken(1))
+```
+
+If you pass cancellation tokens both during metronome initialization and in the `start()` method, their limitations will be summed up.
+
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ At the same time, it may be important to you that even if in some cases the func
 
 ## Metronomes are disposable
 
+The metronome object from this library cannot be used twice. If you started it once and then stopped it, you can't do it again:
+
+```python
+metronome = Metronome(0.2, lambda: print('go!'))
+
+metronome.start()
+sleep(0.2)
+metronome.stop()
+#> go!
+metronome.start()
+#> ...
+#> metronomes.errors.RunStoppedMetronomeError: Metronomes are disposable, you cannot restart a stopped metronome.
+```
+
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This library offers the easiest way to run regular tasks. Just give it a functio
 
 - [**Quick start**](#quick-start)
 - [**Why?**](#why)
+- [**Metronomes are disposable**](#metronomes-are-disposable)
 - [**Logging**](#logging)
 - [**Error escaping**](#error-escaping)
 - [**Working with Cancellation Tokens**](#working-with-cancellation-tokens)
@@ -68,6 +69,8 @@ Its task is to produce sounds regularly and monotonously, which is very convenie
 When we write programs, we also sometimes want some action to be performed regularly. And sometimes it happens that it may take a different amount of time, but we need the next action to start on time. This is exactly the task this library solves. When you call the `start()` method on a metronome object, it starts calling the function you passed once in a certain period of time. This happens in a separate specially created thread, so you can use these function calls to orchestrate some other actions in the main thread or even in several different threads.
 
 At the same time, it may be important to you that even if in some cases the function does not work well and raises exceptions, in general the metronome continues to work, and after a certain time it will try to call this function again, and will not break at the first exception. After all, it would be strange if your real metronome went silent when you made a mistake in the rhythm that you are tapping on the drum, right? You may also want the errors that have occurred not to be lost, but to be recorded in your log. This library also provides all these amenities.
+
+## Metronomes are disposable
 
 
 ## Logging

--- a/metronomes/metronome.py
+++ b/metronomes/metronome.py
@@ -84,6 +84,9 @@ class Metronome:
     def run_loop(self, token: AbstractToken) -> None:
         arguments = [...] if self.suppress_exceptions else []
 
+        if not token:
+            self.logger.info('The metronome did not start working because the cancellation token was canceled right at the start.')
+
         while token:
             start_time = perf_counter()
 

--- a/metronomes/metronome.py
+++ b/metronomes/metronome.py
@@ -52,14 +52,14 @@ class Metronome:
                 self.stop()
         return False
 
-    def start(self) -> 'Metronome':
+    def start(self, token: AbstractToken = DefaultToken()) -> 'Metronome':
         with self.lock:
             if self.stopped:
                 raise RunStoppedMetronomeError('Metronomes are disposable, you cannot restart a stopped metronome.')
             if self.started:
                 raise RunAlreadyStartedMetronomeError('The metronome has already been launched.')
 
-            self.thread = Thread(target=self.run_loop, args=())
+            self.thread = Thread(target=self.run_loop, args=(self.token + token,))
             self.thread.daemon = True
 
             self.logger.info('The metronome starts.')
@@ -81,10 +81,10 @@ class Metronome:
             self.stopped = True
             self.logger.info('The metronome has stopped.')
 
-    def run_loop(self) -> None:
+    def run_loop(self, token: AbstractToken) -> None:
         arguments = [...] if self.suppress_exceptions else []
 
-        while self.token:
+        while token:
             start_time = perf_counter()
 
             self.logger.debug(f'The beginning of the execution of callback "{self.callback.__name__}".')

--- a/metronomes/metronome.py
+++ b/metronomes/metronome.py
@@ -12,14 +12,14 @@ from types import TracebackType
 
 import escape
 from emptylog import EmptyLogger, LoggerProtocol
-from cantok import AbstractToken, SimpleToken, TimeoutToken
+from cantok import AbstractToken, SimpleToken, DefaultToken, TimeoutToken
 from locklib import ContextLockProtocol
 
 from metronomes.errors import RunStoppedMetronomeError, RunAlreadyStartedMetronomeError, StopNotStartedMetronomeError, StopStoppedMetronomeError
 
 
 class Metronome:
-    def __init__(self, iteration: Union[int, float], callback: Callable[[], Any], suppress_exceptions: bool = True, logger: LoggerProtocol = EmptyLogger(), token: Optional[AbstractToken] = None, lock_factory: Union[Type[ContextLockProtocol], Callable[[], ContextLockProtocol]] = RLock, sleeping_callback: Callable[[Union[int, float]], Any] = sleep, duration: Optional[Union[int, float]] = None) -> None:
+    def __init__(self, iteration: Union[int, float], callback: Callable[[], Any], suppress_exceptions: bool = True, logger: LoggerProtocol = EmptyLogger(), token: AbstractToken = DefaultToken(), lock_factory: Union[Type[ContextLockProtocol], Callable[[], ContextLockProtocol]] = RLock, sleeping_callback: Callable[[Union[int, float]], Any] = sleep, duration: Optional[Union[int, float]] = None) -> None:
         if iteration <= 0:
             raise ValueError('The duration of the metronome iteration (tick-tock time) must be greater than zero.')
 
@@ -27,7 +27,7 @@ class Metronome:
         self.callback: Callable[[], Any] = callback
         self.suppress_exceptions: bool = suppress_exceptions
         self.logger: LoggerProtocol = logger
-        self.token: AbstractToken = SimpleToken(token) if token is not None else SimpleToken()
+        self.token: AbstractToken = SimpleToken(token)
         if duration is not None:
             if duration < 0:
                 raise ValueError('The total duration of the metronome operation cannot be less than zero.')

--- a/metronomes/metronome.py
+++ b/metronomes/metronome.py
@@ -62,7 +62,7 @@ class Metronome:
             self.thread = Thread(target=self.run_loop, args=(self.token + token,))
             self.thread.daemon = True
 
-            self.logger.info('The metronome starts.')
+            self.logger.info('The metronome starts...')
             self.thread.start()
             self.started = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ description = 'Endless tick-tock generators'
 readme = 'README.md'
 requires-python = '>=3.7'
 dependencies = [
-    'emptylog>=0.0.4',
-    'cantok>=0.0.22',
-    'escaping>=0.0.11',
+    'emptylog>=0.0.7',
+    'cantok>=0.0.23',
+    'escaping>=0.0.13',
     'locklib>=0.0.15',
     'typing_extensions ; python_version < "3.8"',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'metronomes'
-version = '0.0.3'
+version = '0.0.4'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -273,22 +273,3 @@ def test_numbers_of_threads_into_context_manager():
         assert count_before + 1 == active_count()
 
     assert count_before == active_count()
-
-
-def test_double_running_of_one_metronome_is_possible():
-    actions = []
-    metronome = Metronome(0.1, lambda: (actions.append(1), sleep(0.0001)), sleeping_callback=lambda x: actions.append(2))
-
-    metronome.start()
-    sleep(0.1)
-    metronome.stop()
-
-    assert actions
-
-    lenth_after_first_running = len(actions)
-
-    metronome.start()
-    sleep(0.1)
-    metronome.stop()
-
-    assert len(actions) > lenth_after_first_running

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -147,7 +147,7 @@ def test_cancellation_token_is_stopping_the_metronome():
     assert metronome.stopped == False
 
     token.cancel()
-    sleep(sleep_time * 100)
+    sleep(sleep_time * 200)
 
     assert active_count() == count_before
     assert metronome.stopped == True
@@ -167,7 +167,7 @@ def test_cancellation_token_is_stopping_the_metronome_in_start_method():
     assert metronome.stopped == False
 
     token.cancel()
-    sleep(sleep_time * 100)
+    sleep(sleep_time * 200)
 
     assert active_count() == count_before
     assert metronome.stopped == True

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -153,6 +153,50 @@ def test_cancellation_token_is_stopping_the_metronome():
     assert metronome.stopped == True
 
 
+def test_cancellation_token_is_stopping_the_metronome_in_start_method():
+    sleep_time = 0.0001
+    def callback(): pass
+    logger = MemoryLogger()
+    token = SimpleToken()
+    metronome = Metronome(sleep_time, callback, logger=logger)
+
+    count_before = active_count()
+    metronome.start(token=token)
+
+    assert active_count() == count_before + 1
+    assert metronome.stopped == False
+
+    token.cancel()
+    sleep(sleep_time * 100)
+
+    assert active_count() == count_before
+    assert metronome.stopped == True
+
+
+@pytest.mark.parametrize(
+    ['first_token', 'second_token'],
+    [
+        (SimpleToken(), SimpleToken(cancelled=True)),
+        (SimpleToken(cancelled=True), SimpleToken()),
+        (SimpleToken(cancelled=True), SimpleToken(cancelled=True)),
+    ],
+)
+def test_start_with_cancelled_token(first_token, second_token):
+    actions = []
+    logger = MemoryLogger()
+    metronome = Metronome(0.0001, lambda: actions.append(True), token=first_token, logger=logger)
+
+    metronome.start(token=second_token)
+    sleep(0.0001)
+
+    assert metronome.stopped
+    assert not actions
+    assert len(logger.data) == 2
+    assert len(logger.data.info) == 2
+    assert logger.data.info[0].message == 'The metronome starts.'
+    assert logger.data.info[1].message == 'The metronome did not start working because the cancellation token was canceled right at the start.'
+
+
 def test_behavior_when_the_callback_time_is_bigger_than_loop_time():
     actions = []
     loop_time = 0.0001

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -114,7 +114,7 @@ def test_normal_logs_order():
     metronome.start()
 
     assert len(logger.data.info) == 1
-    assert logger.data.info[0].message == 'The metronome starts.'
+    assert logger.data.info[0].message == 'The metronome starts...'
 
     sleep(0.0001 * 10)
 
@@ -193,7 +193,7 @@ def test_start_with_cancelled_token(first_token, second_token):
     assert not actions
     assert len(logger.data) == 2
     assert len(logger.data.info) == 2
-    assert logger.data.info[0].message == 'The metronome starts.'
+    assert logger.data.info[0].message == 'The metronome starts...'
     assert logger.data.info[1].message == 'The metronome did not start working because the cancellation token was canceled right at the start.'
 
 

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -149,7 +149,6 @@ def test_cancellation_token_is_stopping_the_metronome():
     token.cancel()
     sleep(sleep_time * 100)
 
-    print(active_count(), count_before)
     assert active_count() == count_before
     assert metronome.stopped == True
 

--- a/tests/units/test_metronome.py
+++ b/tests/units/test_metronome.py
@@ -273,3 +273,22 @@ def test_numbers_of_threads_into_context_manager():
         assert count_before + 1 == active_count()
 
     assert count_before == active_count()
+
+
+def test_double_running_of_one_metronome_is_possible():
+    actions = []
+    metronome = Metronome(0.1, lambda: (actions.append(1), sleep(0.0001)), sleeping_callback=lambda x: actions.append(2))
+
+    metronome.start()
+    sleep(0.1)
+    metronome.stop()
+
+    assert actions
+
+    lenth_after_first_running = len(actions)
+
+    metronome.start()
+    sleep(0.1)
+    metronome.stop()
+
+    assert len(actions) > lenth_after_first_running


### PR DESCRIPTION
A little update.

- Upgraded versions of some dependencies.
- Changed the internal implementation of working with cancellation tokens: added `DefaultToken` support.
- Expanded the documentation: it is indicated that metronomes are disposable.
- Added the ability to pass a cancellation token to the `start()` method.
- Added logging in case the cancellation token is canceled from the very beginning.